### PR TITLE
#23 [fix] プロフィール編集画面のバリデーション修正

### DIFF
--- a/app/Http/Requests/ProfileRequest.php
+++ b/app/Http/Requests/ProfileRequest.php
@@ -2,10 +2,19 @@
 
 namespace App\Http\Requests;
 
+use App\Rules\IconRule;
+use App\Rules\ProfilePasswordRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class ProfileRequest extends FormRequest
 {
+    // public function __construct(
+    //     IconRule $icon_rule
+    // ) {
+    //     $this->$icon_rule = $icon_rule;
+    // }
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -26,10 +35,23 @@ class ProfileRequest extends FormRequest
         return [
             //
             'username' => 'min:4|max:12',
-            'mail'=>'min:4|max:12|unique:users,mail',
-            'newPassword'=>'min:4|max:12|unique:users,password|different:password',
-            'bio'=>'max:200',
-            'icon'=>'mimes:jpg,png,bmp,gif,svg',
+            'mail'=>[
+                'required',
+                Rule::unique('users')->ignore(Auth::id()),
+                'min:4',
+            ],
+            'newPassword'=>[
+                'nullable',
+                'min:4',
+                'max:12',
+                'unique:users,password',
+                new ProfilePasswordRule
+            ],
+            'bio'=>'nullable|max:200',
+            'icon'=>[
+                'mimes:jpg,png,bmp,gif,svg',
+                new IconRule
+            ]
         ];
     }
 }

--- a/app/Rules/IconRule.php
+++ b/app/Rules/IconRule.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class IconRule implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        //
+        if (!preg_match('/^[-_a-zA-Z0-9]/', $value->getClientOriginalName())) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'ファイル名を半角英数字に変更してください。';
+    }
+}

--- a/app/Rules/ProfilePasswordRule.php
+++ b/app/Rules/ProfilePasswordRule.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+
+class ProfilePasswordRule implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        //
+        $currentPassword = Auth::user()->password;
+        if(Hash::check($value, $currentPassword)){
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return '現在のパスワードと同じです。';
+    }
+}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -29,11 +29,11 @@
         </div>
         <div class="mb-3">
             {{ Form::label('password', 'Password',['class'=>'label form-label']) }}
-            {{ Form::text('password',null,['class' => 'input form-control']) }}
+            {{ Form::password('password',['class' => 'input form-control']) }}
         </div>
         <div class="mb-3">
             {{ Form::label('password-confirm','Password Confirm',['class'=>'label form-label']) }}
-            {{ Form::text('password_confirmation',null,['class' => 'input form-control']) }}
+            {{ Form::password('password_confirmation',['class' => 'input form-control']) }}
         </div>
         <div class="text-right">
             {{ Form::submit('REGISTER', ['class'=>'btn btn-primary']) }}


### PR DESCRIPTION
メール変更実行時に自身のメールアドレスがuniqueに引っかかっていたので修正。
現在と同じパスワードでもバリデーションされなかったので修正。
アイコンのイメージファイルが日本語でもバリデーションされていなかったので修正。